### PR TITLE
add html&css for user profiles; closes #12

### DIFF
--- a/css/components/user-profile.css
+++ b/css/components/user-profile.css
@@ -4,8 +4,8 @@
   border: none;
   text-align: left;
   font-size: x-small;
-  border-radius: 0px;
-  border-top: 0px;
+  border-radius: 0;
+  border-top: 0;
 }
 
 button.active {
@@ -13,11 +13,9 @@ button.active {
 }
 
 .tab-content {
-  visibility: hidden;
-  height: 0em;
+  display: none;
 }
 
 .quoteSelected {
-  visibility: visible;
-  height: auto;
+  display: initial;
 }

--- a/css/components/user-profile.css
+++ b/css/components/user-profile.css
@@ -1,0 +1,23 @@
+.user_profile {
+  background-color: var(--color-bg-block);
+  color: var(--color-text-body);
+  border: none;
+  text-align: left;
+  font-size: x-small;
+  border-radius: 0px;
+  border-top: 0px;
+}
+
+button.active {
+  border-top: 1px solid var(--color-primary);
+}
+
+.tab-content {
+  visibility: hidden;
+  height: 0em;
+}
+
+.quoteSelected {
+  visibility: visible;
+  height: auto;
+}

--- a/html/index.html
+++ b/html/index.html
@@ -117,31 +117,38 @@
       <h3>What people think about us</h3>
 
       <div class="tab-container">
-        <div class="tab-content-1">
+        <div class="tab-content quoteSelected">
           <p>
             "Lorem ipsum dolor sit amet consectetur adipisicing elit. Ipsa amet
             vitae delectus rem modi atque culpa porro voluptatibus. Suscipit,
             assumenda."
           </p>
         </div>
-        <div class="tab-content-2">
+        <div class="tab-content">
           <p>
             "Lorem ipsum dolor sit amet consectetur adipisicing elit. Ipsa amet
             vitae delectus rem modi atque culpa porro voluptatibus. Suscipit,
             assumenda."
           </p>
         </div>
-        <div class="tab-content-3">
+        <div class="tab-content">
           <p>
             "Lorem ipsum dolor sit amet consectetur adipisicing elit. Ipsa amet
             vitae delectus rem modi atque culpa porro voluptatibus. Suscipit,
             assumenda."
           </p>
         </div>
+
         <div class="tab-buttons">
-          <button class="tab-button-1">First tab quote</button>
-          <button class="tab-button-2">Second tab quote</button>
-          <button class="tab-button-3">Third tab quote</button>
+          <button class="user_profile active">
+            <strong>Dave</strong><br />Something about Dave
+          </button>
+          <button class="user_profile">
+            <strong>Geoffrey</strong><br />Something about Geoffrey
+          </button>
+          <button class="user_profile">
+            <strong>Princess Beatrice</strong><br />Something about PB
+          </button>
         </div>
       </div>
     </section>


### PR DESCRIPTION
User profile tabs and quotes are styled: tab highlighted with a line above and quote only `visible` when the corespondent tab is selected/`active`. 

<img width="1122" height="442" alt="image" src="https://github.com/user-attachments/assets/85350c09-a7c1-44b1-a866-b722f66c4d0c" />
